### PR TITLE
Allow file-only messages

### DIFF
--- a/web/app/components/app/app-publisher/features-wrapper.tsx
+++ b/web/app/components/app/app-publisher/features-wrapper.tsx
@@ -54,6 +54,7 @@ const FeaturesWrappedAppPublisher = (props: Props) => {
         allowed_file_upload_methods: props.publishedConfig.modelConfig.file_upload?.allowed_file_upload_methods || props.publishedConfig.modelConfig.file_upload?.image?.transfer_methods || ['local_file', 'remote_url'],
         number_limits: props.publishedConfig.modelConfig.file_upload?.number_limits || props.publishedConfig.modelConfig.file_upload?.image?.number_limits || 3,
       } as FileUpload
+      draft.fileOnlyMessage = props.publishedConfig.modelConfig.file_only_message || { enabled: false }
     })
     setFeatures(newFeatures)
     setRestoreConfirmOpen(false)

--- a/web/app/components/app/configuration/index.tsx
+++ b/web/app/components/app/configuration/index.tsx
@@ -484,6 +484,7 @@ const Configuration: FC = () => {
         number_limits: modelConfig.file_upload?.number_limits || modelConfig.file_upload?.image?.number_limits || 3,
         fileUploadConfig: fileUploadConfigResponse,
       } as FileUpload,
+      fileOnlyMessage: modelConfig.file_only_message || { enabled: false },
       suggested: modelConfig.suggested_questions_after_answer || { enabled: false },
       citation: modelConfig.retriever_resource || { enabled: false },
       annotationReply: modelConfig.annotation_reply || { enabled: false },
@@ -761,6 +762,7 @@ const Configuration: FC = () => {
       speech_to_text: features?.speech2text as any,
       text_to_speech: features?.text2speech as any,
       file_upload: fileUpload as any,
+      file_only_message: features?.fileOnlyMessage as any,
       suggested_questions_after_answer: features?.suggested as any,
       retriever_resource: features?.citation as any,
       agent_mode: {
@@ -793,6 +795,7 @@ const Configuration: FC = () => {
       draft.suggested_questions_after_answer = suggestedQuestionsAfterAnswerConfig
       draft.speech_to_text = speechToTextConfig
       draft.text_to_speech = textToSpeechConfig
+      draft.file_only_message = features?.fileOnlyMessage
       draft.retriever_resource = citationConfig
       draft.dataSets = dataSets
     })

--- a/web/app/components/base/chat/chat/chat-input-area/index.tsx
+++ b/web/app/components/base/chat/chat/chat-input-area/index.tsx
@@ -26,6 +26,7 @@ import VoiceInput from '@/app/components/base/voice-input'
 import { useToastContext } from '@/app/components/base/toast'
 import FeatureBar from '@/app/components/base/features/new-feature-panel/feature-bar'
 import type { FileUpload } from '@/app/components/base/features/types'
+import { useFeatures } from '@/app/components/base/features/hooks'
 import { TransferMethod } from '@/types/app'
 
 type ChatInputAreaProps = {
@@ -77,6 +78,7 @@ const ChatInputArea = ({
     handleClipboardPasteFile,
     isDragActive,
   } = useFile(visionConfig!)
+  const features = useFeatures(s => s.features)
   const { checkInputsForm } = useCheckInputsForms()
   const historyRef = useRef([''])
   const [currentIndex, setCurrentIndex] = useState(-1)
@@ -94,8 +96,10 @@ const ChatInputArea = ({
         return
       }
       if (!query || !query.trim()) {
-        notify({ type: 'info', message: t('appAnnotation.errorMessage.queryRequired') })
-        return
+        if (!(features.fileOnlyMessage?.enabled && files.length > 0)) {
+          notify({ type: 'info', message: t('appAnnotation.errorMessage.queryRequired') })
+          return
+        }
       }
       if (checkInputsForm(inputs, inputsForm)) {
         onSend(query, files)

--- a/web/app/components/base/features/new-feature-panel/file-only-message.tsx
+++ b/web/app/components/base/features/new-feature-panel/file-only-message.tsx
@@ -1,0 +1,56 @@
+import React, { useCallback } from 'react'
+import { useTranslation } from 'react-i18next'
+import produce from 'immer'
+import { RiFile2Fill } from '@remixicon/react'
+import FeatureCard from '@/app/components/base/features/new-feature-panel/feature-card'
+import { useFeatures, useFeaturesStore } from '@/app/components/base/features/hooks'
+import type { OnFeaturesChange } from '@/app/components/base/features/types'
+import { FeatureEnum } from '@/app/components/base/features/types'
+
+type Props = {
+  disabled?: boolean
+  onChange?: OnFeaturesChange
+}
+
+const FileOnlyMessage = ({
+  disabled,
+  onChange,
+}: Props) => {
+  const { t } = useTranslation()
+  const features = useFeatures(s => s.features)
+  const featuresStore = useFeaturesStore()
+
+  const handleChange = useCallback((type: FeatureEnum, enabled: boolean) => {
+    const {
+      features,
+      setFeatures,
+    } = featuresStore!.getState()
+
+    const newFeatures = produce(features, (draft) => {
+      draft[type] = {
+        ...draft[type],
+        enabled,
+      }
+    })
+    setFeatures(newFeatures)
+    if (onChange)
+      onChange(newFeatures)
+  }, [featuresStore, onChange])
+
+  return (
+    <FeatureCard
+      icon={
+        <div className='shrink-0 rounded-lg border-[0.5px] border-divider-subtle bg-util-colors-blue-blue-600 p-1 shadow-xs'>
+          <RiFile2Fill className='h-4 w-4 text-text-primary-on-surface' />
+        </div>
+      }
+      title={t('appDebug.feature.fileOnlyMessage.title')}
+      value={!!features.fileOnlyMessage?.enabled}
+      description={t('appDebug.feature.fileOnlyMessage.description')!}
+      onChange={state => handleChange(FeatureEnum.fileOnlyMessage, state)}
+      disabled={disabled}
+    />
+  )
+}
+
+export default FileOnlyMessage

--- a/web/app/components/base/features/new-feature-panel/index.tsx
+++ b/web/app/components/base/features/new-feature-panel/index.tsx
@@ -13,6 +13,7 @@ import FollowUp from '@/app/components/base/features/new-feature-panel/follow-up
 import SpeechToText from '@/app/components/base/features/new-feature-panel/speech-to-text'
 import TextToSpeech from '@/app/components/base/features/new-feature-panel/text-to-speech'
 import FileUpload from '@/app/components/base/features/new-feature-panel/file-upload'
+import FileOnlyMessage from '@/app/components/base/features/new-feature-panel/file-only-message'
 import Citation from '@/app/components/base/features/new-feature-panel/citation'
 import ImageUpload from '@/app/components/base/features/new-feature-panel/image-upload'
 import Moderation from '@/app/components/base/features/new-feature-panel/moderation'
@@ -109,6 +110,7 @@ const NewFeaturePanel = ({
             <SpeechToText disabled={disabled} onChange={onChange} />
           )}
           {showFileUpload && isChatMode && <FileUpload disabled={disabled} onChange={onChange} />}
+          {showFileUpload && isChatMode && <FileOnlyMessage disabled={disabled} onChange={onChange} />}
           {showFileUpload && !isChatMode && <ImageUpload disabled={disabled} onChange={onChange} />}
           {isChatMode && (
             <Citation disabled={disabled} onChange={onChange} />

--- a/web/app/components/base/features/store.ts
+++ b/web/app/components/base/features/store.ts
@@ -51,6 +51,9 @@ export const createFeaturesStore = (initProps?: Partial<FeaturesState>) => {
           transfer_methods: [TransferMethod.local_file, TransferMethod.remote_url],
         },
       },
+      fileOnlyMessage: {
+        enabled: false,
+      },
       annotationReply: {
         enabled: false,
       },

--- a/web/app/components/base/features/types.ts
+++ b/web/app/components/base/features/types.ts
@@ -42,6 +42,8 @@ export type FileUpload = {
   fileUploadConfig?: FileUploadConfigResponse
 } & EnabledOrDisabled
 
+export type FileOnlyMessage = EnabledOrDisabled
+
 export type AnnotationReplyConfig = {
   enabled: boolean
   id?: string
@@ -61,6 +63,7 @@ export enum FeatureEnum {
   citation = 'citation',
   moderation = 'moderation',
   file = 'file',
+  fileOnlyMessage = 'fileOnlyMessage',
   annotationReply = 'annotationReply',
 }
 
@@ -73,6 +76,7 @@ export type Features = {
   [FeatureEnum.citation]?: RetrieverResource
   [FeatureEnum.moderation]?: SensitiveWordAvoidance
   [FeatureEnum.file]?: FileUpload
+  [FeatureEnum.fileOnlyMessage]?: FileOnlyMessage
   [FeatureEnum.annotationReply]?: AnnotationReplyConfig
 }
 

--- a/web/app/components/workflow-app/index.tsx
+++ b/web/app/components/workflow-app/index.tsx
@@ -67,6 +67,7 @@ const WorkflowAppWithAdditionalContext = () => {
       number_limits: features.file_upload?.number_limits || features.file_upload?.image?.number_limits || 3,
       fileUploadConfig: fileUploadConfigResponse,
     },
+    fileOnlyMessage: features.file_only_message || { enabled: false },
     opening: {
       enabled: !!features.opening_statement,
       opening_statement: features.opening_statement,

--- a/web/i18n/en-US/app-debug.ts
+++ b/web/i18n/en-US/app-debug.ts
@@ -213,6 +213,10 @@ const translation = {
       numberLimit: 'Max uploads',
       modalTitle: 'Image Upload Setting',
     },
+    fileOnlyMessage: {
+      title: 'Allow Empty Message With File',
+      description: 'Permit sending a blank message when at least one file is attached.',
+    },
     bar: {
       empty: 'Enable feature to enhance web app user experience',
       enableText: 'Features Enabled',

--- a/web/types/app.ts
+++ b/web/types/app.ts
@@ -245,6 +245,9 @@ export type ModelConfig = {
   file_upload?: {
     image: VisionSettings
   } & UploadFileSetting
+  file_only_message?: {
+    enabled: boolean
+  }
   files?: VisionFile[]
   created_at?: number
   updated_at?: number


### PR DESCRIPTION
## Summary
- add a new FileOnlyMessage feature type
- add feature toggle component
- use feature to allow sending blank text when file attached
- expose new setting in app config and workflow app
- document new option in English i18n

## Testing
- `dev/pytest/pytest_unit_tests.sh` *(fails: pytest not found)*
- `pnpm test` in `web` *(fails: jest not found)*