### PR TITLE
Enable local code building with Docker compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,13 @@ cp .env.example .env
 docker compose up -d
 ```
 
+To build the Docker images from your local source code instead of pulling the
+prebuilt images, run:
+
+```bash
+docker compose up -d --build
+```
+
 After running, you can access the Dify dashboard in your browser at [http://localhost/install](http://localhost/install) and start the initialization process.
 
 #### Seeking help

--- a/README_FR.md
+++ b/README_FR.md
@@ -186,6 +186,13 @@ cp .env.example .env
 docker compose up -d
 ```
 
+Pour lancer les images Docker construites à partir de votre copie locale du code
+source, exécutez&nbsp;:
+
+```bash
+docker compose up -d --build
+```
+
 Après l'exécution, vous pouvez accéder au tableau de bord Dify dans votre navigateur à [http://localhost/install](http://localhost/install) et commencer le processus d'initialisation.
 
 > Si vous souhaitez contribuer à Dify ou effectuer un développement supplémentaire, consultez notre [guide de déploiement à partir du code source](https://docs.dify.ai/getting-started/install-self-hosted/local-source-code)

--- a/docker/docker-compose-template.yaml
+++ b/docker/docker-compose-template.yaml
@@ -2,6 +2,8 @@ x-shared-env: &shared-api-worker-env
 services:
   # API service
   api:
+    build:
+      context: ../api
     image: langgenius/dify-api:1.4.0
     restart: always
     environment:
@@ -31,6 +33,8 @@ services:
   # worker service
   # The Celery worker for processing the queue.
   worker:
+    build:
+      context: ../api
     image: langgenius/dify-api:1.4.0
     restart: always
     environment:
@@ -57,6 +61,8 @@ services:
 
   # Frontend web application.
   web:
+    build:
+      context: ../web
     image: langgenius/dify-web:1.4.0
     restart: always
     environment:

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -492,6 +492,8 @@ x-shared-env: &shared-api-worker-env
 services:
   # API service
   api:
+    build:
+      context: ../api
     image: langgenius/dify-api:1.4.0
     restart: always
     environment:
@@ -521,6 +523,8 @@ services:
   # worker service
   # The Celery worker for processing the queue.
   worker:
+    build:
+      context: ../api
     image: langgenius/dify-api:1.4.0
     restart: always
     environment:
@@ -547,6 +551,8 @@ services:
 
   # Frontend web application.
   web:
+    build:
+      context: ../web
     image: langgenius/dify-web:1.4.0
     restart: always
     environment:


### PR DESCRIPTION
## Summary
- let docker-compose build API & web images from local source
- show how to rebuild images in README and README_FR
- regenerate docker-compose.yaml from template

## Testing
- `./generate_docker_compose`
- `git diff --cached --stat`