### PR TITLE
Allow file-only messages

### DIFF
--- a/web/app/components/app/app-publisher/features-wrapper.tsx
+++ b/web/app/components/app/app-publisher/features-wrapper.tsx
@@ -54,6 +54,7 @@ const FeaturesWrappedAppPublisher = (props: Props) => {
         allowed_file_upload_methods: props.publishedConfig.modelConfig.file_upload?.allowed_file_upload_methods || props.publishedConfig.modelConfig.file_upload?.image?.transfer_methods || ['local_file', 'remote_url'],
         number_limits: props.publishedConfig.modelConfig.file_upload?.number_limits || props.publishedConfig.modelConfig.file_upload?.image?.number_limits || 3,
       } as FileUpload
+      draft.fileOnlyMessage = props.publishedConfig.modelConfig.file_only_message || { enabled: false }
     })
     setFeatures(newFeatures)
     setRestoreConfirmOpen(false)

--- a/web/app/components/app/configuration/index.tsx
+++ b/web/app/components/app/configuration/index.tsx
@@ -484,6 +484,7 @@ const Configuration: FC = () => {
         number_limits: modelConfig.file_upload?.number_limits || modelConfig.file_upload?.image?.number_limits || 3,
         fileUploadConfig: fileUploadConfigResponse,
       } as FileUpload,
+      fileOnlyMessage: modelConfig.file_only_message || { enabled: false },
       suggested: modelConfig.suggested_questions_after_answer || { enabled: false },
       citation: modelConfig.retriever_resource || { enabled: false },
       annotationReply: modelConfig.annotation_reply || { enabled: false },
@@ -761,6 +762,7 @@ const Configuration: FC = () => {
       speech_to_text: features?.speech2text as any,
       text_to_speech: features?.text2speech as any,
       file_upload: fileUpload as any,
+      file_only_message: features?.fileOnlyMessage as any,
       suggested_questions_after_answer: features?.suggested as any,
       retriever_resource: features?.citation as any,
       agent_mode: {
@@ -793,6 +795,7 @@ const Configuration: FC = () => {
       draft.suggested_questions_after_answer = suggestedQuestionsAfterAnswerConfig
       draft.speech_to_text = speechToTextConfig
       draft.text_to_speech = textToSpeechConfig
+      draft.file_only_message = features?.fileOnlyMessage
       draft.retriever_resource = citationConfig
       draft.dataSets = dataSets
     })

--- a/web/app/components/base/chat/chat-with-history/index.tsx
+++ b/web/app/components/base/chat/chat-with-history/index.tsx
@@ -2,6 +2,7 @@ import type { FC } from 'react'
 import {
   useEffect,
   useState,
+  useMemo,
 } from 'react'
 import { useAsyncEffect } from 'ahooks'
 import { useThemeContext } from '../embedded-chatbot/theme/theme-context'
@@ -19,6 +20,8 @@ import Loading from '@/app/components/base/loading'
 import useBreakpoints, { MediaType } from '@/hooks/use-breakpoints'
 import { checkOrSetAccessToken } from '@/app/components/share/utils'
 import AppUnavailable from '@/app/components/base/app-unavailable'
+import { FeaturesProvider } from '@/app/components/base/features'
+import type { Features as FeaturesData } from '@/app/components/base/features/types'
 import cn from '@/utils/classnames'
 
 type ChatWithHistoryProps = {
@@ -161,6 +164,10 @@ const ChatWithHistoryWrap: FC<ChatWithHistoryWrapProps> = ({
     setCurrentConversationInputs,
   } = useChatWithHistory(installedAppInfo)
 
+  const featuresData = useMemo<FeaturesData>(() => ({
+    fileOnlyMessage: appParams?.file_only_message || { enabled: false },
+  }), [appParams])
+
   return (
     <ChatWithHistoryContext.Provider value={{
       appInfoError,
@@ -203,7 +210,9 @@ const ChatWithHistoryWrap: FC<ChatWithHistoryWrapProps> = ({
       currentConversationInputs,
       setCurrentConversationInputs,
     }}>
-      <ChatWithHistory className={className} />
+      <FeaturesProvider features={featuresData}>
+        <ChatWithHistory className={className} />
+      </FeaturesProvider>
     </ChatWithHistoryContext.Provider>
   )
 }

--- a/web/app/components/base/chat/chat/chat-input-area/index.tsx
+++ b/web/app/components/base/chat/chat/chat-input-area/index.tsx
@@ -26,6 +26,7 @@ import VoiceInput from '@/app/components/base/voice-input'
 import { useToastContext } from '@/app/components/base/toast'
 import FeatureBar from '@/app/components/base/features/new-feature-panel/feature-bar'
 import type { FileUpload } from '@/app/components/base/features/types'
+import { useFeatures } from '@/app/components/base/features/hooks'
 import { TransferMethod } from '@/types/app'
 
 type ChatInputAreaProps = {
@@ -77,6 +78,7 @@ const ChatInputArea = ({
     handleClipboardPasteFile,
     isDragActive,
   } = useFile(visionConfig!)
+  const features = useFeatures(s => s.features)
   const { checkInputsForm } = useCheckInputsForms()
   const historyRef = useRef([''])
   const [currentIndex, setCurrentIndex] = useState(-1)
@@ -93,12 +95,17 @@ const ChatInputArea = ({
         notify({ type: 'info', message: t('appDebug.errorMessage.waitForFileUpload') })
         return
       }
-      if (!query || !query.trim()) {
-        notify({ type: 'info', message: t('appAnnotation.errorMessage.queryRequired') })
-        return
+      let finalQuery = query
+      if (!finalQuery || !finalQuery.trim()) {
+        if (features.fileOnlyMessage?.enabled && files.length > 0)
+          finalQuery = t('appDebug.feature.fileOnlyMessage.placeholder', { count: files.length }) || 'check this file'
+        else {
+          notify({ type: 'info', message: t('appAnnotation.errorMessage.queryRequired') })
+          return
+        }
       }
       if (checkInputsForm(inputs, inputsForm)) {
-        onSend(query, files)
+        onSend(finalQuery, files)
         setQuery('')
         setFiles([])
       }

--- a/web/app/components/base/chat/embedded-chatbot/index.tsx
+++ b/web/app/components/base/chat/embedded-chatbot/index.tsx
@@ -1,6 +1,7 @@
 import {
   useEffect,
   useState,
+  useMemo,
 } from 'react'
 import { useAsyncEffect } from 'ahooks'
 import { useTranslation } from 'react-i18next'
@@ -14,6 +15,8 @@ import { useThemeContext } from './theme/theme-context'
 import { CssTransform } from './theme/utils'
 import { checkOrSetAccessToken } from '@/app/components/share/utils'
 import AppUnavailable from '@/app/components/base/app-unavailable'
+import { FeaturesProvider } from '@/app/components/base/features'
+import type { Features as FeaturesData } from '@/app/components/base/features/types'
 import useBreakpoints, { MediaType } from '@/hooks/use-breakpoints'
 import Loading from '@/app/components/base/loading'
 import LogoHeader from '@/app/components/base/logo/logo-embedded-chat-header'
@@ -167,6 +170,10 @@ const EmbeddedChatbotWrapper = () => {
     setCurrentConversationInputs,
   } = useEmbeddedChatbot()
 
+  const featuresData = useMemo<FeaturesData>(() => ({
+    fileOnlyMessage: appParams?.file_only_message || { enabled: false },
+  }), [appParams])
+
   return <EmbeddedChatbotContext.Provider value={{
     appInfoError,
     appInfoLoading,
@@ -202,7 +209,9 @@ const EmbeddedChatbotWrapper = () => {
     currentConversationInputs,
     setCurrentConversationInputs,
   }}>
-    <Chatbot />
+    <FeaturesProvider features={featuresData}>
+      <Chatbot />
+    </FeaturesProvider>
   </EmbeddedChatbotContext.Provider>
 }
 

--- a/web/app/components/base/features/new-feature-panel/file-only-message.tsx
+++ b/web/app/components/base/features/new-feature-panel/file-only-message.tsx
@@ -1,0 +1,56 @@
+import React, { useCallback } from 'react'
+import { useTranslation } from 'react-i18next'
+import produce from 'immer'
+import { RiFile2Fill } from '@remixicon/react'
+import FeatureCard from '@/app/components/base/features/new-feature-panel/feature-card'
+import { useFeatures, useFeaturesStore } from '@/app/components/base/features/hooks'
+import type { OnFeaturesChange } from '@/app/components/base/features/types'
+import { FeatureEnum } from '@/app/components/base/features/types'
+
+type Props = {
+  disabled?: boolean
+  onChange?: OnFeaturesChange
+}
+
+const FileOnlyMessage = ({
+  disabled,
+  onChange,
+}: Props) => {
+  const { t } = useTranslation()
+  const features = useFeatures(s => s.features)
+  const featuresStore = useFeaturesStore()
+
+  const handleChange = useCallback((type: FeatureEnum, enabled: boolean) => {
+    const {
+      features,
+      setFeatures,
+    } = featuresStore!.getState()
+
+    const newFeatures = produce(features, (draft) => {
+      draft[type] = {
+        ...draft[type],
+        enabled,
+      }
+    })
+    setFeatures(newFeatures)
+    if (onChange)
+      onChange(newFeatures)
+  }, [featuresStore, onChange])
+
+  return (
+    <FeatureCard
+      icon={
+        <div className='shrink-0 rounded-lg border-[0.5px] border-divider-subtle bg-util-colors-blue-blue-600 p-1 shadow-xs'>
+          <RiFile2Fill className='h-4 w-4 text-text-primary-on-surface' />
+        </div>
+      }
+      title={t('appDebug.feature.fileOnlyMessage.title')}
+      value={!!features.fileOnlyMessage?.enabled}
+      description={t('appDebug.feature.fileOnlyMessage.description')!}
+      onChange={state => handleChange(FeatureEnum.fileOnlyMessage, state)}
+      disabled={disabled}
+    />
+  )
+}
+
+export default FileOnlyMessage

--- a/web/app/components/base/features/new-feature-panel/index.tsx
+++ b/web/app/components/base/features/new-feature-panel/index.tsx
@@ -13,6 +13,7 @@ import FollowUp from '@/app/components/base/features/new-feature-panel/follow-up
 import SpeechToText from '@/app/components/base/features/new-feature-panel/speech-to-text'
 import TextToSpeech from '@/app/components/base/features/new-feature-panel/text-to-speech'
 import FileUpload from '@/app/components/base/features/new-feature-panel/file-upload'
+import FileOnlyMessage from '@/app/components/base/features/new-feature-panel/file-only-message'
 import Citation from '@/app/components/base/features/new-feature-panel/citation'
 import ImageUpload from '@/app/components/base/features/new-feature-panel/image-upload'
 import Moderation from '@/app/components/base/features/new-feature-panel/moderation'
@@ -109,6 +110,7 @@ const NewFeaturePanel = ({
             <SpeechToText disabled={disabled} onChange={onChange} />
           )}
           {showFileUpload && isChatMode && <FileUpload disabled={disabled} onChange={onChange} />}
+          {showFileUpload && isChatMode && <FileOnlyMessage disabled={disabled} onChange={onChange} />}
           {showFileUpload && !isChatMode && <ImageUpload disabled={disabled} onChange={onChange} />}
           {isChatMode && (
             <Citation disabled={disabled} onChange={onChange} />

--- a/web/app/components/base/features/store.ts
+++ b/web/app/components/base/features/store.ts
@@ -51,6 +51,9 @@ export const createFeaturesStore = (initProps?: Partial<FeaturesState>) => {
           transfer_methods: [TransferMethod.local_file, TransferMethod.remote_url],
         },
       },
+      fileOnlyMessage: {
+        enabled: false,
+      },
       annotationReply: {
         enabled: false,
       },

--- a/web/app/components/base/features/types.ts
+++ b/web/app/components/base/features/types.ts
@@ -42,6 +42,8 @@ export type FileUpload = {
   fileUploadConfig?: FileUploadConfigResponse
 } & EnabledOrDisabled
 
+export type FileOnlyMessage = EnabledOrDisabled
+
 export type AnnotationReplyConfig = {
   enabled: boolean
   id?: string
@@ -61,6 +63,7 @@ export enum FeatureEnum {
   citation = 'citation',
   moderation = 'moderation',
   file = 'file',
+  fileOnlyMessage = 'fileOnlyMessage',
   annotationReply = 'annotationReply',
 }
 
@@ -73,6 +76,7 @@ export type Features = {
   [FeatureEnum.citation]?: RetrieverResource
   [FeatureEnum.moderation]?: SensitiveWordAvoidance
   [FeatureEnum.file]?: FileUpload
+  [FeatureEnum.fileOnlyMessage]?: FileOnlyMessage
   [FeatureEnum.annotationReply]?: AnnotationReplyConfig
 }
 

--- a/web/app/components/workflow-app/index.tsx
+++ b/web/app/components/workflow-app/index.tsx
@@ -67,6 +67,7 @@ const WorkflowAppWithAdditionalContext = () => {
       number_limits: features.file_upload?.number_limits || features.file_upload?.image?.number_limits || 3,
       fileUploadConfig: fileUploadConfigResponse,
     },
+    fileOnlyMessage: features.file_only_message || { enabled: false },
     opening: {
       enabled: !!features.opening_statement,
       opening_statement: features.opening_statement,

--- a/web/i18n/en-US/app-debug.ts
+++ b/web/i18n/en-US/app-debug.ts
@@ -213,6 +213,12 @@ const translation = {
       numberLimit: 'Max uploads',
       modalTitle: 'Image Upload Setting',
     },
+    fileOnlyMessage: {
+      title: 'Allow Empty Message With File',
+      description: 'Permit sending a blank message when at least one file is attached.',
+      placeholder_one: 'Check this file',
+      placeholder_other: 'Check these files',
+    },
     bar: {
       empty: 'Enable feature to enhance web app user experience',
       enableText: 'Features Enabled',

--- a/web/i18n/fr-FR/app-debug.ts
+++ b/web/i18n/fr-FR/app-debug.ts
@@ -76,6 +76,12 @@ const translation = {
       description: 'Une fois activé, le texte peut être converti en parole.',
       resDes: 'La Texte à Audio est activée',
     },
+    fileOnlyMessage: {
+      title: "Autoriser l'envoi de message vide avec fichier",
+      description: "Permettre l'envoi d'un message vide lorsqu'au moins un fichier est joint.",
+      placeholder_one: 'Vérifier ce fichier',
+      placeholder_other: 'Vérifier ces fichiers',
+    },
     citation: {
       title: 'Citations et Attributions',
       description: 'Une fois activé, affichez le document source et la section attribuée du contenu généré.',

--- a/web/i18n/ja-JP/app-debug.ts
+++ b/web/i18n/ja-JP/app-debug.ts
@@ -213,6 +213,12 @@ const translation = {
       numberLimit: '最大アップロード数',
       modalTitle: '画像アップロード設置',
     },
+    fileOnlyMessage: {
+      title: 'ファイルのみのメッセージを許可',
+      description: '少なくとも1件のファイルが添付されている場合、空のメッセージを送信できます。',
+      placeholder_one: 'このファイルを確認',
+      placeholder_other: 'これらのファイルを確認',
+    },
     bar: {
       empty: 'Webアプリのユーザーエクスペリアンスを強化させる機能を有効にする',
       enableText: '有効な機能',

--- a/web/i18n/zh-Hans/app-debug.ts
+++ b/web/i18n/zh-Hans/app-debug.ts
@@ -213,6 +213,12 @@ const translation = {
       numberLimit: '最大上传数',
       modalTitle: '图片上传设置',
     },
+    fileOnlyMessage: {
+      title: '允许仅发送附件',
+      description: '在至少上传一个文件时，可以发送空消息。',
+      placeholder_one: '查看此文件',
+      placeholder_other: '查看这些文件',
+    },
     bar: {
       empty: '开启功能增强 webapp 用户体验',
       enableText: '功能已开启',

--- a/web/i18n/zh-Hant/app-debug.ts
+++ b/web/i18n/zh-Hant/app-debug.ts
@@ -76,6 +76,12 @@ const translation = {
       description: '啟用後，文字可以轉換成語音。',
       resDes: '文字轉音訊已啟用',
     },
+    fileOnlyMessage: {
+      title: '允許僅傳送附檔訊息',
+      description: '當至少附加一個檔案時，可傳送空白訊息。',
+      placeholder_one: '查看此檔案',
+      placeholder_other: '查看這些檔案',
+    },
     citation: {
       title: '引用和歸屬',
       description: '啟用後，顯示源文件和生成內容的歸屬部分。',

--- a/web/types/app.ts
+++ b/web/types/app.ts
@@ -245,6 +245,9 @@ export type ModelConfig = {
   file_upload?: {
     image: VisionSettings
   } & UploadFileSetting
+  file_only_message?: {
+    enabled: boolean
+  }
   files?: VisionFile[]
   created_at?: number
   updated_at?: number


### PR DESCRIPTION
## Summary
- allow sending empty message if file attached by injecting placeholder text
- provide placeholder translations for new feature in English, French, and Chinese
- ensure chat components have FeaturesProvider so runtime works

## Testing
- `dev/pytest/pytest_unit_tests.sh` *(fails: ModuleNotFoundError: No module named 'flask')*
- `pnpm test` *(fails: jest not found)*