### PR TITLE
Allow file-only messages

### DIFF
--- a/api/controllers/common/fields.py
+++ b/api/controllers/common/fields.py
@@ -22,6 +22,7 @@ parameters_fields = {
     "user_input_form": fields.Raw,
     "sensitive_word_avoidance": fields.Raw,
     "file_upload": fields.Raw,
+    "file_only_message": fields.Raw,
     "system_parameters": fields.Nested(parameters__system_parameters),
 }
 

--- a/api/core/app/app_config/base_app_config_manager.py
+++ b/api/core/app/app_config/base_app_config_manager.py
@@ -11,6 +11,7 @@ from core.app.app_config.features.suggested_questions_after_answer.manager impor
     SuggestedQuestionsAfterAnswerConfigManager,
 )
 from core.app.app_config.features.text_to_speech.manager import TextToSpeechConfigManager
+from core.app.app_config.features.file_only_message.manager import FileOnlyMessageConfigManager
 from models.model import AppMode
 
 
@@ -45,5 +46,7 @@ class BaseAppConfigManager:
         additional_features.speech_to_text = SpeechToTextConfigManager.convert(config=config_dict)
 
         additional_features.text_to_speech = TextToSpeechConfigManager.convert(config=config_dict)
+
+        additional_features.file_only_message = FileOnlyMessageConfigManager.convert(config=config_dict)
 
         return additional_features

--- a/api/core/app/app_config/common/parameters_mapping/__init__.py
+++ b/api/core/app/app_config/common/parameters_mapping/__init__.py
@@ -35,6 +35,7 @@ def get_parameters_from_feature_dict(
                 }
             },
         ),
+        "file_only_message": features_dict.get("file_only_message", {"enabled": False}),
         "system_parameters": {
             "image_file_size_limit": dify_config.UPLOAD_IMAGE_FILE_SIZE_LIMIT,
             "video_file_size_limit": dify_config.UPLOAD_VIDEO_FILE_SIZE_LIMIT,

--- a/api/core/app/app_config/entities.py
+++ b/api/core/app/app_config/entities.py
@@ -272,6 +272,7 @@ class AppAdditionalFeatures(BaseModel):
     more_like_this: bool = False
     speech_to_text: bool = False
     text_to_speech: Optional[TextToSpeechEntity] = None
+    file_only_message: bool = False
     trace_config: Optional[TracingConfigEntity] = None
 
 

--- a/api/core/app/app_config/features/file_only_message/manager.py
+++ b/api/core/app/app_config/features/file_only_message/manager.py
@@ -1,0 +1,23 @@
+class FileOnlyMessageConfigManager:
+    @classmethod
+    def convert(cls, config: dict) -> bool:
+        """Convert model config to feature flag"""
+        file_only_message = False
+        flag = config.get("file_only_message")
+        if flag and flag.get("enabled"):
+            file_only_message = True
+        return file_only_message
+
+    @classmethod
+    def validate_and_set_defaults(cls, config: dict) -> tuple[dict, list[str]]:
+        """Validate and set defaults for file only message feature"""
+        if not config.get("file_only_message"):
+            config["file_only_message"] = {"enabled": False}
+
+        if not isinstance(config["file_only_message"], dict):
+            raise ValueError("file_only_message must be of dict type")
+
+        if "enabled" not in config["file_only_message"] or not isinstance(config["file_only_message"]["enabled"], bool):
+            config["file_only_message"]["enabled"] = False
+
+        return config, ["file_only_message"]

--- a/api/core/app/apps/advanced_chat/app_config_manager.py
+++ b/api/core/app/apps/advanced_chat/app_config_manager.py
@@ -9,6 +9,7 @@ from core.app.app_config.features.suggested_questions_after_answer.manager impor
     SuggestedQuestionsAfterAnswerConfigManager,
 )
 from core.app.app_config.features.text_to_speech.manager import TextToSpeechConfigManager
+from core.app.app_config.features.file_only_message.manager import FileOnlyMessageConfigManager
 from core.app.app_config.workflow_ui_based_app.variables.manager import WorkflowVariablesConfigManager
 from models.model import App, AppMode
 from models.workflow import Workflow
@@ -53,6 +54,10 @@ class AdvancedChatAppConfigManager(BaseAppConfigManager):
 
         # file upload validation
         config, current_related_config_keys = FileUploadConfigManager.validate_and_set_defaults(config=config)
+        related_config_keys.extend(current_related_config_keys)
+
+        # file_only_message
+        config, current_related_config_keys = FileOnlyMessageConfigManager.validate_and_set_defaults(config)
         related_config_keys.extend(current_related_config_keys)
 
         # opening_statement

--- a/api/core/app/apps/agent_chat/app_config_manager.py
+++ b/api/core/app/apps/agent_chat/app_config_manager.py
@@ -19,6 +19,7 @@ from core.app.app_config.features.suggested_questions_after_answer.manager impor
     SuggestedQuestionsAfterAnswerConfigManager,
 )
 from core.app.app_config.features.text_to_speech.manager import TextToSpeechConfigManager
+from core.app.app_config.features.file_only_message.manager import FileOnlyMessageConfigManager
 from core.entities.agent_entities import PlanningStrategy
 from models.model import App, AppMode, AppModelConfig, Conversation
 
@@ -107,6 +108,10 @@ class AgentChatAppConfigManager(BaseAppConfigManager):
 
         # file upload validation
         config, current_related_config_keys = FileUploadConfigManager.validate_and_set_defaults(config)
+        related_config_keys.extend(current_related_config_keys)
+
+        # file_only_message
+        config, current_related_config_keys = FileOnlyMessageConfigManager.validate_and_set_defaults(config)
         related_config_keys.extend(current_related_config_keys)
 
         # prompt

--- a/api/core/app/apps/chat/app_config_manager.py
+++ b/api/core/app/apps/chat/app_config_manager.py
@@ -15,6 +15,7 @@ from core.app.app_config.features.suggested_questions_after_answer.manager impor
     SuggestedQuestionsAfterAnswerConfigManager,
 )
 from core.app.app_config.features.text_to_speech.manager import TextToSpeechConfigManager
+from core.app.app_config.features.file_only_message.manager import FileOnlyMessageConfigManager
 from models.model import App, AppMode, AppModelConfig, Conversation
 
 
@@ -102,6 +103,10 @@ class ChatAppConfigManager(BaseAppConfigManager):
 
         # file upload validation
         config, current_related_config_keys = FileUploadConfigManager.validate_and_set_defaults(config)
+        related_config_keys.extend(current_related_config_keys)
+
+        # file_only_message
+        config, current_related_config_keys = FileOnlyMessageConfigManager.validate_and_set_defaults(config)
         related_config_keys.extend(current_related_config_keys)
 
         # prompt

--- a/api/core/app/apps/completion/app_config_manager.py
+++ b/api/core/app/apps/completion/app_config_manager.py
@@ -10,6 +10,7 @@ from core.app.app_config.entities import EasyUIBasedAppConfig, EasyUIBasedAppMod
 from core.app.app_config.features.file_upload.manager import FileUploadConfigManager
 from core.app.app_config.features.more_like_this.manager import MoreLikeThisConfigManager
 from core.app.app_config.features.text_to_speech.manager import TextToSpeechConfigManager
+from core.app.app_config.features.file_only_message.manager import FileOnlyMessageConfigManager
 from models.model import App, AppMode, AppModelConfig
 
 
@@ -87,6 +88,10 @@ class CompletionAppConfigManager(BaseAppConfigManager):
 
         # file upload validation
         config, current_related_config_keys = FileUploadConfigManager.validate_and_set_defaults(config)
+        related_config_keys.extend(current_related_config_keys)
+
+        # file_only_message
+        config, current_related_config_keys = FileOnlyMessageConfigManager.validate_and_set_defaults(config)
         related_config_keys.extend(current_related_config_keys)
 
         # prompt

--- a/api/core/app/apps/workflow/app_config_manager.py
+++ b/api/core/app/apps/workflow/app_config_manager.py
@@ -3,6 +3,7 @@ from core.app.app_config.common.sensitive_word_avoidance.manager import Sensitiv
 from core.app.app_config.entities import WorkflowUIBasedAppConfig
 from core.app.app_config.features.file_upload.manager import FileUploadConfigManager
 from core.app.app_config.features.text_to_speech.manager import TextToSpeechConfigManager
+from core.app.app_config.features.file_only_message.manager import FileOnlyMessageConfigManager
 from core.app.app_config.workflow_ui_based_app.variables.manager import WorkflowVariablesConfigManager
 from models.model import App, AppMode
 from models.workflow import Workflow
@@ -47,6 +48,10 @@ class WorkflowAppConfigManager(BaseAppConfigManager):
 
         # file upload validation
         config, current_related_config_keys = FileUploadConfigManager.validate_and_set_defaults(config=config)
+        related_config_keys.extend(current_related_config_keys)
+
+        # file_only_message
+        config, current_related_config_keys = FileOnlyMessageConfigManager.validate_and_set_defaults(config)
         related_config_keys.extend(current_related_config_keys)
 
         # text_to_speech

--- a/api/fields/app_fields.py
+++ b/api/fields/app_fields.py
@@ -40,6 +40,7 @@ model_config_fields = {
     "completion_prompt_config": fields.Raw(attribute="completion_prompt_config_dict"),
     "dataset_configs": fields.Raw(attribute="dataset_configs_dict"),
     "file_upload": fields.Raw(attribute="file_upload_dict"),
+    "file_only_message": fields.Raw(attribute="file_only_message_dict"),
     "created_by": fields.String,
     "created_at": TimestampField,
     "updated_by": fields.String,

--- a/api/migrations/versions/abcdef123456_add_file_only_message_feature.py
+++ b/api/migrations/versions/abcdef123456_add_file_only_message_feature.py
@@ -1,0 +1,24 @@
+"""add file_only_message feature
+
+Revision ID: abcdef123456
+Revises: fecff1c3da27
+Create Date: 2025-05-20 16:00:00.000000
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = 'abcdef123456'
+down_revision = 'fecff1c3da27'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('app_model_configs', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('file_only_message', sa.Text(), nullable=True))
+
+
+def downgrade():
+    with op.batch_alter_table('app_model_configs', schema=None) as batch_op:
+        batch_op.drop_column('file_only_message')

--- a/api/models/model.py
+++ b/api/models/model.py
@@ -327,6 +327,7 @@ class AppModelConfig(Base):
     dataset_configs = db.Column(db.Text)
     external_data_tools = db.Column(db.Text)
     file_upload = db.Column(db.Text)
+    file_only_message = db.Column(db.Text)
 
     @property
     def app(self):
@@ -447,6 +448,10 @@ class AppModelConfig(Base):
             }
         )
 
+    @property
+    def file_only_message_dict(self) -> dict:
+        return json.loads(self.file_only_message) if self.file_only_message else {"enabled": False}
+
     def to_dict(self) -> dict:
         return {
             "opening_statement": self.opening_statement,
@@ -469,6 +474,7 @@ class AppModelConfig(Base):
             "completion_prompt_config": self.completion_prompt_config_dict,
             "dataset_configs": self.dataset_configs_dict,
             "file_upload": self.file_upload_dict,
+            "file_only_message": self.file_only_message_dict,
         }
 
     def from_model_config_dict(self, model_config: Mapping[str, Any]):
@@ -515,6 +521,7 @@ class AppModelConfig(Base):
             json.dumps(model_config.get("dataset_configs")) if model_config.get("dataset_configs") else None
         )
         self.file_upload = json.dumps(model_config.get("file_upload")) if model_config.get("file_upload") else None
+        self.file_only_message = json.dumps(model_config.get("file_only_message")) if model_config.get("file_only_message") else None
         return self
 
     def copy(self):
@@ -540,6 +547,7 @@ class AppModelConfig(Base):
             completion_prompt_config=self.completion_prompt_config,
             dataset_configs=self.dataset_configs,
             file_upload=self.file_upload,
+            file_only_message=self.file_only_message,
         )
 
         return new_app_model_config

--- a/web/app/components/app/app-publisher/features-wrapper.tsx
+++ b/web/app/components/app/app-publisher/features-wrapper.tsx
@@ -54,6 +54,7 @@ const FeaturesWrappedAppPublisher = (props: Props) => {
         allowed_file_upload_methods: props.publishedConfig.modelConfig.file_upload?.allowed_file_upload_methods || props.publishedConfig.modelConfig.file_upload?.image?.transfer_methods || ['local_file', 'remote_url'],
         number_limits: props.publishedConfig.modelConfig.file_upload?.number_limits || props.publishedConfig.modelConfig.file_upload?.image?.number_limits || 3,
       } as FileUpload
+      draft.fileOnlyMessage = props.publishedConfig.modelConfig.file_only_message || { enabled: false }
     })
     setFeatures(newFeatures)
     setRestoreConfirmOpen(false)

--- a/web/app/components/app/configuration/index.tsx
+++ b/web/app/components/app/configuration/index.tsx
@@ -484,6 +484,7 @@ const Configuration: FC = () => {
         number_limits: modelConfig.file_upload?.number_limits || modelConfig.file_upload?.image?.number_limits || 3,
         fileUploadConfig: fileUploadConfigResponse,
       } as FileUpload,
+      fileOnlyMessage: modelConfig.file_only_message || { enabled: false },
       suggested: modelConfig.suggested_questions_after_answer || { enabled: false },
       citation: modelConfig.retriever_resource || { enabled: false },
       annotationReply: modelConfig.annotation_reply || { enabled: false },
@@ -761,6 +762,7 @@ const Configuration: FC = () => {
       speech_to_text: features?.speech2text as any,
       text_to_speech: features?.text2speech as any,
       file_upload: fileUpload as any,
+      file_only_message: features?.fileOnlyMessage as any,
       suggested_questions_after_answer: features?.suggested as any,
       retriever_resource: features?.citation as any,
       agent_mode: {
@@ -793,6 +795,7 @@ const Configuration: FC = () => {
       draft.suggested_questions_after_answer = suggestedQuestionsAfterAnswerConfig
       draft.speech_to_text = speechToTextConfig
       draft.text_to_speech = textToSpeechConfig
+      draft.file_only_message = features?.fileOnlyMessage
       draft.retriever_resource = citationConfig
       draft.dataSets = dataSets
     })

--- a/web/app/components/base/chat/chat/chat-input-area/index.tsx
+++ b/web/app/components/base/chat/chat/chat-input-area/index.tsx
@@ -26,6 +26,7 @@ import VoiceInput from '@/app/components/base/voice-input'
 import { useToastContext } from '@/app/components/base/toast'
 import FeatureBar from '@/app/components/base/features/new-feature-panel/feature-bar'
 import type { FileUpload } from '@/app/components/base/features/types'
+import { useFeatures } from '@/app/components/base/features/hooks'
 import { TransferMethod } from '@/types/app'
 
 type ChatInputAreaProps = {
@@ -77,6 +78,7 @@ const ChatInputArea = ({
     handleClipboardPasteFile,
     isDragActive,
   } = useFile(visionConfig!)
+  const features = useFeatures(s => s.features)
   const { checkInputsForm } = useCheckInputsForms()
   const historyRef = useRef([''])
   const [currentIndex, setCurrentIndex] = useState(-1)
@@ -93,12 +95,17 @@ const ChatInputArea = ({
         notify({ type: 'info', message: t('appDebug.errorMessage.waitForFileUpload') })
         return
       }
-      if (!query || !query.trim()) {
-        notify({ type: 'info', message: t('appAnnotation.errorMessage.queryRequired') })
-        return
+      let finalQuery = query
+      if (!finalQuery || !finalQuery.trim()) {
+        if (features.fileOnlyMessage?.enabled && files.length > 0)
+          finalQuery = t('appDebug.feature.fileOnlyMessage.placeholder', { count: files.length })
+        else {
+          notify({ type: 'info', message: t('appAnnotation.errorMessage.queryRequired') })
+          return
+        }
       }
       if (checkInputsForm(inputs, inputsForm)) {
-        onSend(query, files)
+        onSend(finalQuery, files)
         setQuery('')
         setFiles([])
       }

--- a/web/app/components/base/features/new-feature-panel/file-only-message.tsx
+++ b/web/app/components/base/features/new-feature-panel/file-only-message.tsx
@@ -1,0 +1,56 @@
+import React, { useCallback } from 'react'
+import { useTranslation } from 'react-i18next'
+import produce from 'immer'
+import { RiFile2Fill } from '@remixicon/react'
+import FeatureCard from '@/app/components/base/features/new-feature-panel/feature-card'
+import { useFeatures, useFeaturesStore } from '@/app/components/base/features/hooks'
+import type { OnFeaturesChange } from '@/app/components/base/features/types'
+import { FeatureEnum } from '@/app/components/base/features/types'
+
+type Props = {
+  disabled?: boolean
+  onChange?: OnFeaturesChange
+}
+
+const FileOnlyMessage = ({
+  disabled,
+  onChange,
+}: Props) => {
+  const { t } = useTranslation()
+  const features = useFeatures(s => s.features)
+  const featuresStore = useFeaturesStore()
+
+  const handleChange = useCallback((type: FeatureEnum, enabled: boolean) => {
+    const {
+      features,
+      setFeatures,
+    } = featuresStore!.getState()
+
+    const newFeatures = produce(features, (draft) => {
+      draft[type] = {
+        ...draft[type],
+        enabled,
+      }
+    })
+    setFeatures(newFeatures)
+    if (onChange)
+      onChange(newFeatures)
+  }, [featuresStore, onChange])
+
+  return (
+    <FeatureCard
+      icon={
+        <div className='shrink-0 rounded-lg border-[0.5px] border-divider-subtle bg-util-colors-blue-blue-600 p-1 shadow-xs'>
+          <RiFile2Fill className='h-4 w-4 text-text-primary-on-surface' />
+        </div>
+      }
+      title={t('appDebug.feature.fileOnlyMessage.title')}
+      value={!!features.fileOnlyMessage?.enabled}
+      description={t('appDebug.feature.fileOnlyMessage.description')!}
+      onChange={state => handleChange(FeatureEnum.fileOnlyMessage, state)}
+      disabled={disabled}
+    />
+  )
+}
+
+export default FileOnlyMessage

--- a/web/app/components/base/features/new-feature-panel/index.tsx
+++ b/web/app/components/base/features/new-feature-panel/index.tsx
@@ -13,6 +13,7 @@ import FollowUp from '@/app/components/base/features/new-feature-panel/follow-up
 import SpeechToText from '@/app/components/base/features/new-feature-panel/speech-to-text'
 import TextToSpeech from '@/app/components/base/features/new-feature-panel/text-to-speech'
 import FileUpload from '@/app/components/base/features/new-feature-panel/file-upload'
+import FileOnlyMessage from '@/app/components/base/features/new-feature-panel/file-only-message'
 import Citation from '@/app/components/base/features/new-feature-panel/citation'
 import ImageUpload from '@/app/components/base/features/new-feature-panel/image-upload'
 import Moderation from '@/app/components/base/features/new-feature-panel/moderation'
@@ -109,6 +110,7 @@ const NewFeaturePanel = ({
             <SpeechToText disabled={disabled} onChange={onChange} />
           )}
           {showFileUpload && isChatMode && <FileUpload disabled={disabled} onChange={onChange} />}
+          {showFileUpload && isChatMode && <FileOnlyMessage disabled={disabled} onChange={onChange} />}
           {showFileUpload && !isChatMode && <ImageUpload disabled={disabled} onChange={onChange} />}
           {isChatMode && (
             <Citation disabled={disabled} onChange={onChange} />

--- a/web/app/components/base/features/store.ts
+++ b/web/app/components/base/features/store.ts
@@ -51,6 +51,9 @@ export const createFeaturesStore = (initProps?: Partial<FeaturesState>) => {
           transfer_methods: [TransferMethod.local_file, TransferMethod.remote_url],
         },
       },
+      fileOnlyMessage: {
+        enabled: false,
+      },
       annotationReply: {
         enabled: false,
       },

--- a/web/app/components/base/features/types.ts
+++ b/web/app/components/base/features/types.ts
@@ -42,6 +42,8 @@ export type FileUpload = {
   fileUploadConfig?: FileUploadConfigResponse
 } & EnabledOrDisabled
 
+export type FileOnlyMessage = EnabledOrDisabled
+
 export type AnnotationReplyConfig = {
   enabled: boolean
   id?: string
@@ -61,6 +63,7 @@ export enum FeatureEnum {
   citation = 'citation',
   moderation = 'moderation',
   file = 'file',
+  fileOnlyMessage = 'fileOnlyMessage',
   annotationReply = 'annotationReply',
 }
 
@@ -73,6 +76,7 @@ export type Features = {
   [FeatureEnum.citation]?: RetrieverResource
   [FeatureEnum.moderation]?: SensitiveWordAvoidance
   [FeatureEnum.file]?: FileUpload
+  [FeatureEnum.fileOnlyMessage]?: FileOnlyMessage
   [FeatureEnum.annotationReply]?: AnnotationReplyConfig
 }
 

--- a/web/app/components/workflow-app/index.tsx
+++ b/web/app/components/workflow-app/index.tsx
@@ -67,6 +67,7 @@ const WorkflowAppWithAdditionalContext = () => {
       number_limits: features.file_upload?.number_limits || features.file_upload?.image?.number_limits || 3,
       fileUploadConfig: fileUploadConfigResponse,
     },
+    fileOnlyMessage: features.file_only_message || { enabled: false },
     opening: {
       enabled: !!features.opening_statement,
       opening_statement: features.opening_statement,

--- a/web/i18n/de-DE/app-debug.ts
+++ b/web/i18n/de-DE/app-debug.ts
@@ -76,6 +76,12 @@ const translation = {
       description: 'Einmal aktiviert, kann Text in Sprache umgewandelt werden.',
       resDes: 'Text zu Audio ist aktiviert',
     },
+    fileOnlyMessage: {
+      title: 'Leere Nachricht mit Datei erlauben',
+      description: 'Ermöglicht das Senden einer leeren Nachricht, wenn mindestens eine Datei angehängt ist.',
+      placeholder_one: 'Schau dir diese Datei an',
+      placeholder_other: 'Schau dir diese Dateien an',
+    },
     citation: {
       title: 'Zitate und Urheberangaben',
       description: 'Einmal aktiviert, zeigen Sie das Quelldokument und den zugeordneten Abschnitt des generierten Inhalts an.',

--- a/web/i18n/en-US/app-debug.ts
+++ b/web/i18n/en-US/app-debug.ts
@@ -213,6 +213,12 @@ const translation = {
       numberLimit: 'Max uploads',
       modalTitle: 'Image Upload Setting',
     },
+    fileOnlyMessage: {
+      title: 'Allow Empty Message With File',
+      description: 'Permit sending a blank message when at least one file is attached.',
+      placeholder_one: 'Check this file',
+      placeholder_other: 'Check these files',
+    },
     bar: {
       empty: 'Enable feature to enhance web app user experience',
       enableText: 'Features Enabled',

--- a/web/i18n/es-ES/app-debug.ts
+++ b/web/i18n/es-ES/app-debug.ts
@@ -76,6 +76,12 @@ const translation = {
       description: 'Una vez habilitado, el texto puede convertirse en voz.',
       resDes: 'Texto a Audio habilitado',
     },
+    fileOnlyMessage: {
+      title: 'Permitir mensaje vacío con archivo',
+      description: 'Permite enviar un mensaje en blanco cuando hay al menos un archivo adjunto.',
+      placeholder_one: 'Revisa este archivo',
+      placeholder_other: 'Revisa estos archivos',
+    },
     citation: {
       title: 'Citas y Atribuciones',
       description: 'Una vez habilitado, muestra el documento fuente y la sección atribuida del contenido generado.',

--- a/web/i18n/fr-FR/app-debug.ts
+++ b/web/i18n/fr-FR/app-debug.ts
@@ -76,6 +76,12 @@ const translation = {
       description: 'Une fois activé, le texte peut être converti en parole.',
       resDes: 'La Texte à Audio est activée',
     },
+    fileOnlyMessage: {
+      title: 'Autoriser le message vide avec fichier',
+      description: 'Permettre l\'envoi d\'un message vide lorsqu\'au moins un fichier est joint.',
+      placeholder_one: 'Vérifiez ce fichier',
+      placeholder_other: 'Vérifiez ces fichiers',
+    },
     citation: {
       title: 'Citations et Attributions',
       description: 'Une fois activé, affichez le document source et la section attribuée du contenu généré.',

--- a/web/types/app.ts
+++ b/web/types/app.ts
@@ -245,6 +245,9 @@ export type ModelConfig = {
   file_upload?: {
     image: VisionSettings
   } & UploadFileSetting
+  file_only_message?: {
+    enabled: boolean
+  }
   files?: VisionFile[]
   created_at?: number
   updated_at?: number


### PR DESCRIPTION
## Summary
- add backend storage and migration for `file_only_message`
- expose new flag in config managers and serialization
- inject placeholder text if message body is blank
- translate placeholder text in several languages

## Testing
- `dev/pytest/pytest_unit_tests.sh` *(fails: ModuleNotFoundError: No module named 'flask')*
- `pnpm test` *(fails: jest not found)*